### PR TITLE
XXX: This is what happens when we deploy a non-bare repo

### DIFF
--- a/fusionbox/fabric/update.py
+++ b/fusionbox/fabric/update.py
@@ -23,15 +23,12 @@ def update_with_git(branch):
             abort("Remote repo dirty, aborting...")
         run("git stash")
 
-    # If branch is not on server, get it
-    if not has_git_branch(branch):
-        run("git fetch origin {0}".format(branch))
-        run("git fetch")
+    run("git fetch")
 
     # Update and get previous remote HEAD
     run("git checkout '{0}'".format(branch))
     remote_head = run("git rev-list --no-merges --max-count=1 HEAD")
-    run("git pull origin {0}".format(branch))
+    run("git reset --hard origin/{0}".format(branch))
 
     return remote_head
 


### PR DESCRIPTION
@clarkbarz had this case:
- live is `aaaaa`
- merge master in live
- fab deploy
- now live is `bbbbb`
- Scott reverts by doing: `git checkout live && git reset --hard aaa && git push origin live --force`
- fab deploy

Since fab deploy does `git pull` (which does git merge in the background) nothing happens, and the revert is not effective.

I'm working on a new project layout (where `media/`, `static/` and `backups/` are not in the project) so that we don't have to use `git` (but `rsync --delete`). We won't have those problem. (And we won't have the migration problem either, migrations are still available through `.pyc` files)
