### PR TITLE
New-style fabric tasks are defined with decorator

### DIFF
--- a/fusionbox/fabric/django/__init__.py
+++ b/fusionbox/fabric/django/__init__.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import os
 import subprocess
 
-from fabric.api import run, cd, puts, local, get, env
+from fabric.api import run, cd, puts, local, get, env, task
 
 from fusionbox.fabric import fb_env
 from fusionbox.fabric.git import get_git_branch
@@ -11,6 +11,7 @@ from fusionbox.fabric.update import get_update_function
 from fusionbox.fabric.utils import virtualenv, files_changed
 
 
+@task
 def stage(pip=False, migrate=False, syncdb=False, branch=None, post_update=None, role='dev'):
     """
     Updates the remote site files to your local branch head, collects static
@@ -54,6 +55,7 @@ def stage(pip=False, migrate=False, syncdb=False, branch=None, post_update=None,
         run(restart_cmd)
 
 
+@task
 def deploy(post_update=None):
     """
     Same as stage, but always uses the live branch and live config settings,


### PR DESCRIPTION
A recent version of Fabric introduced a new way to define tasks.
Now, when it loads fabfiles, Fabric mutually excludes either all
tasks that were defined the classic way or all tasks defined the
new-style way.

A recent version of fusionbox-fabric-helpers introduced a new
manner of deploying and staging using the new-style tasks.
Projects that attempt to use the old way of deploying and the new
way of staging (or vice versa) will not able to do both.
