### PR TITLE
Use syncdb --migrate instead of syncdb then migrate

### DIFF
--- a/fusionbox/fabric/django/__init__.py
+++ b/fusionbox/fabric/django/__init__.py
@@ -46,11 +46,8 @@ def stage(pip=False, migrate=False, syncdb=False, branch=None, post_update=None,
                 run('python manage.py backupdb')
 
             if get_django_version() < (1, 7):  # Django 1.7 introduced migrations
-                if syncdb:
-                    run('python manage.py syncdb')
-
-                if migrate:
-                    run('python manage.py migrate')
+                if syncdb or migrate:
+                    run('python manage.py syncdb --migrate')
             else:
                 if syncdb or migrate:
                     run('python manage.py migrate')


### PR DESCRIPTION
Some applications work when they're done as a single step but not separately. (django-constance is the I'm having trouble with).